### PR TITLE
Annots is sometimes parsed by prawn as a PDF::Core::Reference

### DIFF
--- a/lib/prawn/blank.rb
+++ b/lib/prawn/blank.rb
@@ -73,7 +73,13 @@ module Prawn
 
       # Add field to annots
       state.page.dictionary.data[:Annots] ||= []
-      state.page.dictionary.data[:Annots] << field
+      
+      if state.page.dictionary.data[:Annots].is_a?(PDF::Core::Reference)
+        state.page.dictionary.data[:Annots].data << field
+      else
+        state.page.dictionary.data[:Annots] << field
+      end
+
       field
     end
   end


### PR DESCRIPTION
in such case, the array is on the data attribute. append to that instead